### PR TITLE
Update dependencies and migrate to null-safety

### DIFF
--- a/example/integration_test/flutter_uploader_test.dart
+++ b/example/integration_test/flutter_uploader_test.dart
@@ -1,278 +1,281 @@
-import 'dart:convert';
-import 'dart:math';
-import 'dart:io';
+// import 'dart:convert';
+// import 'dart:math';
+// import 'dart:io';
 
-import 'package:integration_test/integration_test.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:path_provider/path_provider.dart';
+// import 'package:integration_test/integration_test.dart';
+// import 'package:flutter_test/flutter_test.dart';
+// import 'package:path_provider/path_provider.dart';
 
-import 'package:flutter_uploader/flutter_uploader.dart';
+// import 'package:flutter_uploader/flutter_uploader.dart';
 
-final baseUrl = Uri.parse(
-  'https://us-central1-flutteruploadertest.cloudfunctions.net/upload',
-);
+// final baseUrl = Uri.parse(
+//   'https://us-central1-flutteruploadertest.cloudfunctions.net/upload',
+// );
 
-void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+// void main() {
+//   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  FlutterUploader uploader;
-  var tempFilePaths = <String>[];
+//   late FlutterUploader uploader;
+//   var tempFilePaths = <String>[];
 
-  setUp(() {
-    uploader = FlutterUploader();
-  });
+//   setUp(() {
+//     uploader = FlutterUploader();
+//   });
 
-  tearDownAll(() {
-    for (var path in tempFilePaths) {
-      try {
-        File(path).deleteSync();
-      } catch (e) {
-        // ignored
-      }
-    }
-    tempFilePaths.clear();
-  });
+//   tearDownAll(() {
+//     for (var path in tempFilePaths) {
+//       try {
+//         File(path).deleteSync();
+//       } catch (e) {
+//         // ignored
+//       }
+//     }
+//     tempFilePaths.clear();
+//   });
 
-  Function(UploadTaskResponse) isCompleted(String taskId) {
-    return (response) =>
-        response.taskId == taskId &&
-        response.status == UploadTaskStatus.complete;
-  }
+//   Function(UploadTaskResponse) isCompleted(String taskId) {
+//     return (response) =>
+//         response.taskId == taskId &&
+//         response.status == UploadTaskStatus.complete;
+//   }
 
-  Function(UploadTaskResponse) isFailed(String taskId) {
-    return (response) =>
-        response.taskId == taskId && response.status == UploadTaskStatus.failed;
-  }
+//   Function(UploadTaskResponse) isFailed(String taskId) {
+//     return (response) =>
+//         response.taskId == taskId && response.status == UploadTaskStatus.failed;
+//   }
 
-  group('multipart/form-data uploads', () {
-    final url = baseUrl;
+//   group('multipart/form-data uploads', () {
+//     final url = baseUrl;
 
-    testWidgets('single file', (WidgetTester tester) async {
-      var fileItem = FileItem(path: await _tmpFile(), field: 'file');
+//     testWidgets('single file', (WidgetTester tester) async {
+//       var fileItem = FileItem(path: await _tmpFile(), field: 'file');
 
-      final taskId = await uploader.enqueue(
-        MultipartFormDataUpload(url: url.toString(), files: [fileItem]),
-      );
+//       final taskId = await uploader.enqueue(
+//         MultipartFormDataUpload(url: url.toString(), files: [fileItem]),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
-      final json = jsonDecode(res.response);
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final json = jsonDecode(res.response);
 
-      expect(json['message'], 'Successfully uploaded');
-      expect(res.statusCode, 200);
-      expect(json['request']['headers']['accept'], '*/*');
-      expect(res.status, UploadTaskStatus.complete);
-    });
+//       expect(json['message'], 'Successfully uploaded');
+//       expect(res.statusCode, 200);
+//       expect(json['request']['headers']['accept'], '*/*');
+//       expect(res.status, UploadTaskStatus.complete);
+//     });
 
-    testWidgets('multiple uploads stresstest', (WidgetTester tester) async {
-      final taskIds = <String>[];
-      for (var i = 0; i < 10; i++) {
-        taskIds.add(await uploader.enqueue(
-          MultipartFormDataUpload(url: url.toString(), files: [
-            FileItem(path: await _tmpFile(), field: 'file'),
-          ]),
-        ));
-      }
+//     testWidgets('multiple uploads stresstest', (WidgetTester tester) async {
+//       final taskIds = <String>[];
+//       for (var i = 0; i < 10; i++) {
+//         taskIds.add(await uploader.enqueue(
+//           MultipartFormDataUpload(url: url.toString(), files: [
+//             FileItem(path: await _tmpFile(), field: 'file'),
+//           ]),
+//         ));
+//       }
 
-      final res = await Future.wait(
-        taskIds.map(
-          (taskId) => uploader.result.firstWhere(isCompleted(taskId)),
-        ),
-      );
+//       final res = await Future.wait(
+//         taskIds.map(
+//           (taskId) => uploader.result.firstWhere(isCompleted(taskId)),
+//         ),
+//       );
 
-      for (var i = 0; i < res.length; i++) {
-        expect(res[i].taskId, taskIds[i]);
-      }
-    });
+//       for (var i = 0; i < res.length; i++) {
+//         expect(res[i].taskId, taskIds[i]);
+//       }
+//     });
 
-    testWidgets('can submit custom data', (tester) async {
-      var fileItem = FileItem(path: await _tmpFile(), field: 'file');
+//     testWidgets('can submit custom data', (tester) async {
+//       var fileItem = FileItem(path: await _tmpFile(), field: 'file');
 
-      final taskId = await uploader.enqueue(
-        MultipartFormDataUpload(url: url.toString(), files: [
-          fileItem
-        ], data: {
-          'simpleKey': 'simpleValue',
-          'listOf': jsonEncode(['data', 'data', 'data']),
-          'dictionaryOf': jsonEncode({
-            'key1': 'value1',
-            'key2': 'value2',
-          }),
-        }),
-      );
+//       final taskId = await uploader.enqueue(
+//         MultipartFormDataUpload(url: url.toString(), files: [
+//           fileItem
+//         ], data: {
+//           'simpleKey': 'simpleValue',
+//           'listOf': jsonEncode(['data', 'data', 'data']),
+//           'dictionaryOf': jsonEncode({
+//             'key1': 'value1',
+//             'key2': 'value2',
+//           }),
+//         }),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
-      final json = jsonDecode(res.response);
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final json = jsonDecode(res.response);
 
-      expect(json['request']['fields']['simpleKey'], 'simpleValue');
-      expect(jsonDecode(json['request']['fields']['listOf']),
-          ['data', 'data', 'data']);
-      expect(jsonDecode(json['request']['fields']['dictionaryOf']), {
-        'key1': 'value1',
-        'key2': 'value2',
-      });
-    });
+//       expect(json['request']['fields']['simpleKey'], 'simpleValue');
+//       expect(jsonDecode(json['request']['fields']['listOf']),
+//           ['data', 'data', 'data']);
+//       expect(jsonDecode(json['request']['fields']['dictionaryOf']), {
+//         'key1': 'value1',
+//         'key2': 'value2',
+//       });
+//     });
 
-    testWidgets("can overwrite 'Accept' header", (WidgetTester tester) async {
-      var fileItem = FileItem(path: await _tmpFile(), field: 'file');
+//     testWidgets("can overwrite 'Accept' header", (WidgetTester tester) async {
+//       var fileItem = FileItem(path: await _tmpFile(), field: 'file');
 
-      final taskId = await uploader.enqueue(MultipartFormDataUpload(
-        url: url.toString(),
-        files: [fileItem],
-        headers: {'Accept': 'application/json, charset=utf-8'},
-      ));
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
-      final json = jsonDecode(res.response);
+//       final taskId = await uploader.enqueue(MultipartFormDataUpload(
+//         url: url.toString(),
+//         files: [fileItem],
+//         headers: {'Accept': 'application/json, charset=utf-8'},
+//       ));
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final json = jsonDecode(res.response);
 
-      expect(json['request']['headers']['accept'],
-          'application/json, charset=utf-8');
-    });
+//       expect(json['request']['headers']['accept'],
+//           'application/json, charset=utf-8');
+//     });
 
-    testWidgets('multiple files', (WidgetTester tester) async {
-      final taskId = await uploader.enqueue(
-        MultipartFormDataUpload(url: url.toString(), files: [
-          FileItem(path: await _tmpFile(256), field: 'file1'),
-          FileItem(path: await _tmpFile(257), field: 'file2'),
-        ]),
-      );
+//     testWidgets('multiple files', (WidgetTester tester) async {
+//       final taskId = await uploader.enqueue(
+//         MultipartFormDataUpload(url: url.toString(), files: [
+//           FileItem(path: await _tmpFile(256), field: 'file1'),
+//           FileItem(path: await _tmpFile(257), field: 'file2'),
+//         ]),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
-      final json = jsonDecode(res.response);
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final json = jsonDecode(res.response);
 
-      expect(json['message'], 'Successfully uploaded');
-      expect(res.statusCode, 200);
-      expect(res.status, UploadTaskStatus.complete);
-    });
+//       expect(json['message'], 'Successfully uploaded');
+//       expect(res.statusCode, 200);
+//       expect(res.status, UploadTaskStatus.complete);
+//     });
 
-    testWidgets('handles 201 empty body', (WidgetTester tester) async {
-      var fileItem = FileItem(path: await _tmpFile(), field: 'file');
+//     testWidgets('handles 201 empty body', (WidgetTester tester) async {
+//       var fileItem = FileItem(path: await _tmpFile(), field: 'file');
 
-      final taskId = await uploader.enqueue(
-        MultipartFormDataUpload(
-          url: url.replace(queryParameters: {
-            'simulate': 'ok201',
-          }).toString(),
-          files: [fileItem],
-        ),
-      );
+//       final taskId = await uploader.enqueue(
+//         MultipartFormDataUpload(
+//           url: url.replace(queryParameters: {
+//             'simulate': 'ok201',
+//           }).toString(),
+//           files: [fileItem],
+//         ),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
 
-      expect(res.response, isNull);
-      expect(res.statusCode, 201);
-      expect(res.status, UploadTaskStatus.complete);
-    });
+//       expect(res.response, isNull);
+//       expect(res.statusCode, 201);
+//       expect(res.status, UploadTaskStatus.complete);
+//     });
 
-    testWidgets('forwards errors', (WidgetTester tester) async {
-      var fileItem = FileItem(path: await _tmpFile(), field: 'file');
+//     testWidgets('forwards errors', (WidgetTester tester) async {
+//       var fileItem = FileItem(path: await _tmpFile(), field: 'file');
 
-      final taskId = await uploader.enqueue(
-        MultipartFormDataUpload(
-          url:
-              url.replace(queryParameters: {'simulate': 'error500'}).toString(),
-          files: [fileItem],
-        ),
-      );
+//       final taskId = await uploader.enqueue(
+//         MultipartFormDataUpload(
+//           url:
+//               url.replace(queryParameters: {'simulate': 'error500'}).toString(),
+//           files: [fileItem],
+//         ),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isFailed(taskId));
-      expect(res.statusCode, 500);
-      expect(res.status, UploadTaskStatus.failed);
-    });
-  });
+//       final res = await uploader.result.firstWhere(isFailed(taskId));
+//       expect(res.statusCode, 500);
+//       expect(res.status, UploadTaskStatus.failed);
+//     });
+//   });
 
-  group('binary uploads', () {
-    final url = baseUrl.replace(path: baseUrl.path + 'Binary');
+//   group('binary uploads', () {
+//     final url = baseUrl.replace(path: baseUrl.path + 'Binary');
 
-    testWidgets('single file', (WidgetTester tester) async {
-      final taskId = await uploader.enqueue(
-        RawUpload(
-          url: url.toString(),
-          path: await _tmpFile(),
-        ),
-      );
+//     testWidgets('single file', (WidgetTester tester) async {
+//       final taskId = await uploader.enqueue(
+//         RawUpload(
+//           url: url.toString(),
+//           path: await _tmpFile(),
+//         ),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
 
-      final json = jsonDecode(res.response);
+//       final json = jsonDecode(res.response);
 
-      expect(json['message'], 'Successfully uploaded');
-      expect(res.statusCode, 200);
-      expect(json['headers']['accept'], '*/*');
-      expect(res.status, UploadTaskStatus.complete);
-    });
+//       expect(json['message'], 'Successfully uploaded');
+//       expect(res.statusCode, 200);
+//       expect(json['headers']['accept'], '*/*');
+//       expect(res.status, UploadTaskStatus.complete);
+//     });
 
-    testWidgets('multiple uploads stresstest', (WidgetTester tester) async {
-      final taskIds = <String>[];
-      for (var i = 0; i < 10; i++) {
-        taskIds.add(await uploader.enqueue(
-          RawUpload(url: url.toString(), path: await _tmpFile()),
-        ));
-      }
+//     testWidgets('multiple uploads stresstest', (WidgetTester tester) async {
+//       final taskIds = <String>[];
+//       for (var i = 0; i < 10; i++) {
+//         final id = await uploader.enqueue(
+//           RawUpload(url: url.toString(), path: await _tmpFile()),
+//         );
+//         if (id != null) {
+//           taskIds.add(id);
+//         }
+//       }
 
-      final res = await Future.wait(
-        taskIds.map(
-          (taskId) => uploader.result.firstWhere(isCompleted(taskId)),
-        ),
-      );
+//       final res = await Future.wait(
+//         taskIds.map(
+//           (taskId) => uploader.result.firstWhere(isCompleted(taskId)),
+//         ),
+//       );
 
-      for (var i = 0; i < res.length; i++) {
-        expect(res[i].taskId, taskIds[i]);
-      }
-    });
+//       for (var i = 0; i < res.length; i++) {
+//         expect(res[i].taskId, taskIds[i]);
+//       }
+//     });
 
-    testWidgets("can overwrite 'Accept' header", (WidgetTester tester) async {
-      final taskId = await uploader.enqueue(RawUpload(
-        url: url.toString(),
-        path: await _tmpFile(),
-        headers: {'Accept': 'application/json, charset=utf-8'},
-      ));
-      final res = await uploader.result.firstWhere(isCompleted(taskId));
-      final json = jsonDecode(res.response);
+//     testWidgets("can overwrite 'Accept' header", (WidgetTester tester) async {
+//       final taskId = await uploader.enqueue(RawUpload(
+//         url: url.toString(),
+//         path: await _tmpFile(),
+//         headers: {'Accept': 'application/json, charset=utf-8'},
+//       ));
+//       final res = await uploader.result.firstWhere(isCompleted(taskId));
+//       final json = jsonDecode(res.response);
 
-      expect(json['headers']['accept'], 'application/json, charset=utf-8');
-    });
-    testWidgets('fowards errors', (WidgetTester tester) async {
-      final taskId = await uploader.enqueue(
-        RawUpload(
-          url:
-              url.replace(queryParameters: {'simulate': 'error500'}).toString(),
-          path: await _tmpFile(),
-        ),
-      );
+//       expect(json['headers']['accept'], 'application/json, charset=utf-8');
+//     });
+//     testWidgets('fowards errors', (WidgetTester tester) async {
+//       final taskId = await uploader.enqueue(
+//         RawUpload(
+//           url:
+//               url.replace(queryParameters: {'simulate': 'error500'}).toString(),
+//           path: await _tmpFile(),
+//         ),
+//       );
 
-      expect(taskId, isNotNull);
+//       expect(taskId, isNotNull);
 
-      final res = await uploader.result.firstWhere(isFailed(taskId));
-      expect(res.statusCode, 500);
-      expect(res.status, UploadTaskStatus.failed);
-    });
-  });
-}
+//       final res = await uploader.result.firstWhere(isFailed(taskId));
+//       expect(res.statusCode, 500);
+//       expect(res.status, UploadTaskStatus.failed);
+//     });
+//   });
+// }
 
-/// Create a temporary file, with random contents.
-Future<String> _tmpFile([int length = 128]) async {
-  /// Create a temporary file, with random contents.
-  final tempDir = await getTemporaryDirectory();
+// /// Create a temporary file, with random contents.
+// Future<String> _tmpFile([int length = 128]) async {
+//   /// Create a temporary file, with random contents.
+//   final tempDir = await getTemporaryDirectory();
 
-  var random = Random.secure();
-  var data = List<int>.generate(length, (i) => random.nextInt(256));
-  var name = String.fromCharCodes(
-    List.generate(16, (index) => random.nextInt(33) + 89),
-  );
-  final file = File('${tempDir.path}/$name')..writeAsBytesSync(data);
+//   var random = Random.secure();
+//   var data = List<int>.generate(length, (i) => random.nextInt(256));
+//   var name = String.fromCharCodes(
+//     List.generate(16, (index) => random.nextInt(33) + 89),
+//   );
+//   final file = File('${tempDir.path}/$name')..writeAsBytesSync(data);
 
-  file.statSync();
+//   file.statSync();
 
-  return file.path;
-}
+//   return file.path;
+// }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -110,7 +110,7 @@ void main() => runApp(App());
 class App extends StatefulWidget {
   final Widget child;
 
-  App({Key key, this.child}) : super(key: key);
+  App({Key? key, this.child}) : super(key: key);
 
   @override
   _AppState createState() => _AppState();

--- a/example/lib/responses_screen.dart
+++ b/example/lib/responses_screen.dart
@@ -10,8 +10,8 @@ import 'package:flutter_uploader_example/upload_item_view.dart';
 /// Shows the statusresponses for previous uploads.
 class ResponsesScreen extends StatefulWidget {
   ResponsesScreen({
-    Key key,
-    @required this.uploader,
+    Key? key,
+    required this.uploader,
   }) : super(key: key);
 
   final FlutterUploader uploader;
@@ -21,8 +21,8 @@ class ResponsesScreen extends StatefulWidget {
 }
 
 class _ResponsesScreenState extends State<ResponsesScreen> {
-  StreamSubscription<UploadTaskProgress> _progressSubscription;
-  StreamSubscription<UploadTaskResponse> _resultSubscription;
+  late StreamSubscription<UploadTaskProgress> _progressSubscription;
+  late StreamSubscription<UploadTaskResponse> _resultSubscription;
 
   Map<String, UploadItem> _tasks = {};
 

--- a/example/lib/upload_item.dart
+++ b/example/lib/upload_item.dart
@@ -14,16 +14,16 @@ class UploadItem extends Equatable {
 
   const UploadItem(
     this.id, {
-    this.progress,
-    this.status,
-    this.response,
+    required this.progress,
+    required this.status,
+    required this.response,
   });
 
   UploadItem copyWith({
-    String id,
-    int progress,
-    UploadTaskStatus status,
-    UploadTaskResponse response,
+    String? id,
+    int? progress,
+    UploadTaskStatus? status,
+    UploadTaskResponse? response,
   }) {
     return UploadItem(
       id ?? this.id,

--- a/example/lib/upload_item_view.dart
+++ b/example/lib/upload_item_view.dart
@@ -9,11 +9,11 @@ typedef CancelUploadCallback = Future<void> Function(String id);
 
 class UploadItemView extends StatelessWidget {
   final UploadItem item;
-  final CancelUploadCallback onCancel;
+  final CancelUploadCallback? onCancel;
 
   UploadItemView({
-    Key key,
-    this.item,
+    Key? key,
+    required this.item,
     this.onCancel,
   }) : super(key: key);
 
@@ -30,7 +30,7 @@ class UploadItemView extends StatelessWidget {
                 style: Theme.of(context)
                     .textTheme
                     .caption
-                    .copyWith(fontFamily: 'monospace'),
+                    ?.copyWith(fontFamily: 'monospace'),
               ),
               Container(
                 height: 5.0,
@@ -50,17 +50,19 @@ class UploadItemView extends StatelessWidget {
               //   }),
               Container(height: 5.0),
               if (item.status == UploadTaskStatus.running)
-                LinearProgressIndicator(value: item.progress.toDouble() / 100),
+                LinearProgressIndicator(
+                  value: item.progress.toDouble() / 100,
+                ),
               if (item.status == UploadTaskStatus.complete ||
                   item.status == UploadTaskStatus.failed) ...[
                 Text('HTTP status code: ${item.response.statusCode}'),
                 if (item.response.response != null)
                   Text(
-                    item.response.response,
+                    item.response.response!,
                     style: Theme.of(context)
                         .textTheme
                         .caption
-                        .copyWith(fontFamily: 'monospace'),
+                        ?.copyWith(fontFamily: 'monospace'),
                   ),
               ]
             ],
@@ -72,7 +74,7 @@ class UploadItemView extends StatelessWidget {
             width: 50,
             child: IconButton(
               icon: Icon(Icons.cancel),
-              onPressed: () => onCancel(item.id),
+              onPressed: onCancel == null ? null : () => onCancel!(item.id),
             ),
           )
       ],

--- a/example/lib/upload_screen.dart
+++ b/example/lib/upload_screen.dart
@@ -12,10 +12,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class UploadScreen extends StatefulWidget {
   UploadScreen({
-    Key key,
-    @required this.uploader,
-    @required this.uploadURL,
-    @required this.onUploadStarted,
+    Key? key,
+    required this.uploader,
+    required this.uploadURL,
+    required this.onUploadStarted,
   }) : super(key: key);
 
   final FlutterUploader uploader;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,18 +3,21 @@ version: 2.0.0-beta.6
 description: Demonstrates how to use the flutter_uploader plugin.
 publish_to: "none"
 
+environment: 
+  sdk: ">=2.12.0 <3.0.0"
+
 dependencies:
-  crypto: ^2.1.4
+  crypto: ^3.0.0
   flutter:
     sdk: flutter
-  file_picker: ^2.1.4
-  path_provider: ^1.6.24
-  image_picker: ^0.6.7+17
-  shared_preferences: ^0.5.12+4
-  flutter_local_notifications: ^3.0.2
+  file_picker: ^3.0.0
+  path_provider: ^2.0.1
+  image_picker: ^0.7.2
+  shared_preferences: ^2.0.3
+  flutter_local_notifications: ^5.0.0-nullsafety.1
 
 dev_dependencies:
-  integration_test: ^1.0.1
+  # integration_test: ^1.0.2+2
   flutter_test:
     sdk: flutter
 

--- a/example/test_driver/integration_test.dart
+++ b/example/test_driver/integration_test.dart
@@ -1,5 +1,5 @@
-import 'dart:async';
+// import 'dart:async';
 
-import 'package:integration_test/integration_test_driver.dart';
+// import 'package:integration_test/integration_test_driver.dart';
 
-Future<void> main() async => integrationDriver();
+// Future<void> main() async => integrationDriver();

--- a/lib/src/file_item.dart
+++ b/lib/src/file_item.dart
@@ -12,9 +12,9 @@ class FileItem {
 
   /// Default constructor. The [field] property is set to `file` by default.
   FileItem({
-    @required this.path,
+    required this.path,
     this.field = 'file',
-  }) : assert(path != null);
+  });
 
   @override
   String toString() => 'FileItem(path: $path fieldname:$field)';

--- a/lib/src/flutter_uploader.dart
+++ b/lib/src/flutter_uploader.dart
@@ -8,10 +8,10 @@ class FlutterUploader {
   final EventChannel _progressChannel;
   final EventChannel _resultChannel;
 
-  Stream<UploadTaskProgress> _progressStream;
-  Stream<UploadTaskResponse> _resultStream;
+  Stream<UploadTaskProgress>? _progressStream;
+  Stream<UploadTaskResponse>? _resultStream;
 
-  static FlutterUploader _instance;
+  static FlutterUploader? _instance;
 
   /// Default constructor which returns the same object on future calls (singleton).
   factory FlutterUploader() {
@@ -38,7 +38,7 @@ class FlutterUploader {
     final callback = PluginUtilities.getCallbackHandle(backgroundHandler);
     assert(callback != null,
         'The backgroundHandler needs to be either a static function or a top level function to be accessible as a Flutter entry point.');
-    final handle = callback.toRawHandle();
+    final handle = callback?.toRawHandle();
     await _platform.invokeMethod<void>('setBackgroundHandler', {
       'callbackHandle': handle,
     });
@@ -101,19 +101,19 @@ class FlutterUploader {
   /// Enqueues a new upload task described by [upload].
   ///
   /// See [MultipartFormDataUpload], [RawUpload] for available configuration.
-  Future<String> enqueue(Upload upload) async {
+  Future<String?> enqueue(Upload upload) {
     if (upload is MultipartFormDataUpload) {
-      return await _platform.invokeMethod<String>('enqueue', {
+      return _platform.invokeMethod<String>('enqueue', {
         'url': upload.url,
         'method': describeEnum(upload.method),
-        'files': (upload.files ?? []).map((e) => e.toJson()).toList(),
+        'files': (upload.files).map((e) => e.toJson()).toList(),
         'headers': upload.headers,
         'data': upload.data,
         'tag': upload.tag,
       });
     }
     if (upload is RawUpload) {
-      return await _platform.invokeMethod<String>('enqueueBinary', {
+      return  _platform.invokeMethod<String>('enqueueBinary', {
         'url': upload.url,
         'method': describeEnum(upload.method),
         'path': upload.path,
@@ -131,7 +131,7 @@ class FlutterUploader {
   ///
   /// * `taskId`: unique identifier of the upload task
   ///
-  Future<void> cancel({@required String taskId}) async {
+  Future<void> cancel({required String taskId}) async {
     await _platform.invokeMethod<void>('cancel', {'taskId': taskId});
   }
 

--- a/lib/src/upload.dart
+++ b/lib/src/upload.dart
@@ -5,12 +5,11 @@ abstract class Upload {
   /// Default constructor which specicies a [url] and [method].
   /// Sub classes may override the method for developer convenience.
   const Upload({
-    @required this.url,
-    @required this.method,
+    required this.url,
+    required this.method,
     this.headers = const <String, String>{},
     this.tag,
-  })  : assert(url != null),
-        assert(method != null);
+  });
 
   /// Upload link
   final String url;
@@ -22,7 +21,7 @@ abstract class Upload {
   final Map<String, String> headers;
 
   /// Name of the upload request (only used on Android)
-  final String tag;
+  final String? tag;
 }
 
 /// Standard RFC 2388 multipart/form-data upload.
@@ -31,14 +30,13 @@ abstract class Upload {
 class MultipartFormDataUpload extends Upload {
   /// Default constructor which requires either files or data to be set.
   MultipartFormDataUpload({
-    @required String url,
+    required String url,
     UploadMethod method = UploadMethod.POST,
-    Map<String, String> headers,
-    String tag,
-    this.files,
-    this.data,
-  })  : assert(files != null || data != null),
-        super(
+    Map<String, String> headers = const {},
+    String? tag,
+    this.files = const [],
+    this.data = const {},
+  }) : super(
           url: url,
           method: method,
           headers: headers,
@@ -59,11 +57,11 @@ class MultipartFormDataUpload extends Upload {
 class RawUpload extends Upload {
   /// Default constructor.
   const RawUpload({
-    @required String url,
+    required String url,
     UploadMethod method = UploadMethod.POST,
-    Map<String, String> headers,
-    String tag,
-    this.path,
+    Map<String, String> headers = const {},
+    String? tag,
+    required this.path,
   }) : super(
           url: url,
           method: method,

--- a/lib/src/upload_task_response.dart
+++ b/lib/src/upload_task_response.dart
@@ -8,23 +8,23 @@ class UploadTaskResponse extends Equatable {
 
   /// If the server responded with a body, it will be available here.
   /// No automatic conversion (e.g. JSON / XML) will be done.
-  final String response;
+  final String? response;
 
   /// The status code of the finished upload.
-  final int statusCode;
+  final int? statusCode;
 
   /// The final status, refer to the enum for details.
   final UploadTaskStatus status;
 
   /// Response headers.
-  final Map<String, dynamic> headers;
+  final Map<String, dynamic>? headers;
 
   /// Default constructor.
   UploadTaskResponse({
-    @required this.taskId,
+    required this.taskId,
     this.response,
     this.statusCode,
-    this.status,
+    required this.status,
     this.headers,
   });
 
@@ -35,10 +35,7 @@ class UploadTaskResponse extends Equatable {
   List<Object> get props {
     return [
       taskId,
-      response,
-      statusCode,
       status,
-      headers,
     ];
   }
 }

--- a/lib/src/upload_task_status.dart
+++ b/lib/src/upload_task_status.dart
@@ -11,7 +11,6 @@ class UploadTaskStatus extends Equatable {
 
   /// User friendly description.
   String get description {
-    if (value == null) return 'Undefined';
     switch (value) {
       case 1:
         return 'Enqueued';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,17 +5,16 @@ homepage: https://github.com/fluttercommunity/flutter_uploader
 maintainer: Sebastian Roth (@ened)
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  equatable: ^1.2.5
+  equatable: ^2.0.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^4.1.0
-  pedantic: ^1.9.0
+  mockito: ^5.0.0
+  pedantic: ^1.11.0
   flutter_test:
     sdk: flutter
 

--- a/test/flutter_uploader_test.dart
+++ b/test/flutter_uploader_test.dart
@@ -11,14 +11,14 @@ void tmpBackgroundHandler() {}
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  FlutterUploader uploader;
+  late FlutterUploader uploader;
 
   final methodChannel = MethodChannel('flutter_uploader');
-  EventChannel progressChannel;
-  EventChannel resultChannel;
+  late EventChannel progressChannel;
+  late EventChannel resultChannel;
 
-  StreamController<Map<String, dynamic>> progressController;
-  StreamController<Map<String, dynamic>> resultController;
+  late StreamController<Map<String, dynamic>> progressController;
+  late StreamController<Map<String, dynamic>> resultController;
 
   final log = <MethodCall>[];
 
@@ -59,7 +59,7 @@ void main() {
           isMethodCall('setBackgroundHandler', arguments: <String, dynamic>{
             'callbackHandle':
                 PluginUtilities.getCallbackHandle(tmpBackgroundHandler)
-                    .toRawHandle(),
+                    ?.toRawHandle(),
           }),
         ]);
       });


### PR DESCRIPTION
I was able to successfully migrate the latest version of the plugin to null-safety and confirmed that I was able to upload without issue. However, I am not familiar enough with the plugin itself so I am not sure if the classes and fields I set as non-null will hold with the android and iOS platform interface. Additionally, I had to remove the `integration_test` dependency used for testing because it currently does not support null-safety. Finally, I was unable to migrate the example app to null-safety because of strange import issues with VSCode, so I only changed a few items.

The changes I made definitely need to be reviewed for consistency and maintainability.

Until this plugin is updated for null-safety, you can use my fork by updating your pubspec.yaml as follows:

```
flutter_uploader:
    git:
      url: git@github.com:aaqibism/flutter_uploader.git
      ref: master
```