### PR TITLE
#187 Add allowCellular flag to Upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add flag to restrict uploads to wifi only
+
 ## 3.0.0-beta.2
 
 - Android: Restore concurrency setting for uploads (#174).

--- a/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
@@ -1,7 +1,6 @@
 package com.bluechilli.flutteruploader;
 
 import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.work.BackoffPolicy;
@@ -11,15 +10,12 @@ import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
-
 import com.bluechilli.flutteruploader.plugin.StatusListener;
 import com.google.gson.Gson;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,236 +28,231 @@ import java.util.concurrent.TimeUnit;
 
 public class MethodCallHandlerImpl implements MethodCallHandler {
 
-    /**
-     * The generic {@link WorkManager} tag which matches any upload.
-     */
-    public static final String FLUTTER_UPLOAD_WORK_TAG = "flutter_upload_task";
+  /** The generic {@link WorkManager} tag which matches any upload. */
+  public static final String FLUTTER_UPLOAD_WORK_TAG = "flutter_upload_task";
 
-    private final Context context;
+  private final Context context;
 
-    private final int connectionTimeout;
+  private final int connectionTimeout;
 
-    @NonNull
-    private final StatusListener statusListener;
+  @NonNull private final StatusListener statusListener;
 
-    private final Executor workManagerExecutor = Executors.newSingleThreadExecutor();
-    private final Executor mainExecutor;
+  private final Executor workManagerExecutor = Executors.newSingleThreadExecutor();
+  private final Executor mainExecutor;
 
-    private static final List<String> VALID_HTTP_METHODS = Arrays.asList("POST", "PUT", "PATCH");
+  private static final List<String> VALID_HTTP_METHODS = Arrays.asList("POST", "PUT", "PATCH");
 
-    MethodCallHandlerImpl(Context context, int timeout, @NonNull StatusListener listener) {
-        mainExecutor = ContextCompat.getMainExecutor(context);
-        this.context = context;
-        this.connectionTimeout = timeout;
-        this.statusListener = listener;
+  MethodCallHandlerImpl(Context context, int timeout, @NonNull StatusListener listener) {
+    mainExecutor = ContextCompat.getMainExecutor(context);
+    this.context = context;
+    this.connectionTimeout = timeout;
+    this.statusListener = listener;
+  }
+
+  @Override
+  public void onMethodCall(MethodCall call, @NonNull Result result) {
+    switch (call.method) {
+      case "setBackgroundHandler":
+        setBackgroundHandler(call, result);
+        break;
+      case "enqueue":
+        enqueue(call, result);
+        break;
+      case "enqueueBinary":
+        enqueueBinary(call, result);
+        break;
+      case "cancel":
+        cancel(call, result);
+        break;
+      case "cancelAll":
+        cancelAll(call, result);
+        break;
+      case "clearUploads":
+        clearUploads(call, result);
+        break;
+      default:
+        result.notImplemented();
+        break;
+    }
+  }
+
+  void setBackgroundHandler(MethodCall call, MethodChannel.Result result) {
+    Long callbackHandle = call.argument("callbackHandle");
+    if (callbackHandle != null) {
+      SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle);
     }
 
-    @Override
-    public void onMethodCall(MethodCall call, @NonNull Result result) {
-        switch (call.method) {
-            case "setBackgroundHandler":
-                setBackgroundHandler(call, result);
-                break;
-            case "enqueue":
-                enqueue(call, result);
-                break;
-            case "enqueueBinary":
-                enqueueBinary(call, result);
-                break;
-            case "cancel":
-                cancel(call, result);
-                break;
-            case "cancelAll":
-                cancelAll(call, result);
-                break;
-            case "clearUploads":
-                clearUploads(call, result);
-                break;
-            default:
-                result.notImplemented();
-                break;
-        }
+    result.success(null);
+  }
+
+  private void enqueue(MethodCall call, MethodChannel.Result result) {
+    String url = call.argument("url");
+    String method = call.argument("method");
+    List<Map<String, String>> files = call.argument("files");
+    Map<String, String> parameters = call.argument("data");
+    Map<String, String> headers = call.argument("headers");
+    String tag = call.argument("tag");
+    Boolean allowCellular = call.<Boolean>argument("allowCellular");
+
+    if (method == null) {
+      method = "POST";
     }
 
-    void setBackgroundHandler(MethodCall call, MethodChannel.Result result) {
-        Long callbackHandle = call.argument("callbackHandle");
-        if (callbackHandle != null) {
-            SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle);
-        }
-
-        result.success(null);
+    if (files == null || files.isEmpty()) {
+      result.error("invalid_call", "Invalid call parameters passed", null);
+      return;
     }
 
-    private void enqueue(MethodCall call, MethodChannel.Result result) {
-        String url = call.argument("url");
-        String method = call.argument("method");
-        List<Map<String, String>> files = call.argument("files");
-        Map<String, String> parameters = call.argument("data");
-        Map<String, String> headers = call.argument("headers");
-        String tag = call.argument("tag");
-        Boolean allowCellular = call.<Boolean>argument("allowCellular");
-
-        if (method == null) {
-            method = "POST";
-        }
-
-        if (files == null || files.isEmpty()) {
-            result.error("invalid_call", "Invalid call parameters passed", null);
-            return;
-        }
-
-        if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
-            result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
-            return;
-        }
-
-        List<FileItem> items = new ArrayList<>();
-
-        for (Map<String, String> file : files) {
-            items.add(FileItem.fromJson(file));
-        }
-        WorkRequest request =
-                buildRequest(
-                        new UploadTask(
-                                url,
-                                method,
-                                items,
-                                headers,
-                                parameters,
-                                connectionTimeout,
-                                false,
-                                tag,
-                                allowCellular != null ? allowCellular : true
-                        )
-                );
-
-        WorkManager.getInstance(context)
-                .enqueue(request)
-                .getResult()
-                .addListener(
-                        () -> {
-                            String taskId = request.getId().toString();
-                            mainExecutor.execute(
-                                    () -> {
-                                        result.success(taskId);
-                                        statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
-                                    });
-                        },
-                        workManagerExecutor);
+    if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
+      result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
+      return;
     }
 
-    private void enqueueBinary(MethodCall call, MethodChannel.Result result) {
-        String url = call.argument("url");
-        String method = call.argument("method");
-        String path = call.argument("path");
-        Map<String, String> headers = call.argument("headers");
-        String tag = call.argument("tag");
-        Boolean allowCellular = call.<Boolean>argument("allowCellular");
+    List<FileItem> items = new ArrayList<>();
 
-        if (method == null) {
-            method = "POST";
-        }
+    for (Map<String, String> file : files) {
+      items.add(FileItem.fromJson(file));
+    }
+    WorkRequest request =
+        buildRequest(
+            new UploadTask(
+                url,
+                method,
+                items,
+                headers,
+                parameters,
+                connectionTimeout,
+                false,
+                tag,
+                allowCellular != null ? allowCellular : true));
 
-        if (path == null) {
-            result.error("invalid_call", "Invalid call parameters passed", null);
-            return;
-        }
+    WorkManager.getInstance(context)
+        .enqueue(request)
+        .getResult()
+        .addListener(
+            () -> {
+              String taskId = request.getId().toString();
+              mainExecutor.execute(
+                  () -> {
+                    result.success(taskId);
+                    statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
+                  });
+            },
+            workManagerExecutor);
+  }
 
-        if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
-            result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
-            return;
-        }
+  private void enqueueBinary(MethodCall call, MethodChannel.Result result) {
+    String url = call.argument("url");
+    String method = call.argument("method");
+    String path = call.argument("path");
+    Map<String, String> headers = call.argument("headers");
+    String tag = call.argument("tag");
+    Boolean allowCellular = call.<Boolean>argument("allowCellular");
 
-        WorkRequest request =
-                buildRequest(
-                        new UploadTask(
-                                url,
-                                method,
-                                Collections.singletonList(new FileItem(path)),
-                                headers,
-                                Collections.emptyMap(),
-                                connectionTimeout,
-                                true,
-                                tag,
-                                allowCellular != null ? allowCellular : true
-                        )
-                );
-        WorkManager.getInstance(context)
-                .enqueue(request)
-                .getResult()
-                .addListener(
-                        () -> {
-                            String taskId = request.getId().toString();
-                            mainExecutor.execute(
-                                    () -> {
-                                        result.success(taskId);
-                                        statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
-                                    });
-                        },
-                        workManagerExecutor);
+    if (method == null) {
+      method = "POST";
     }
 
-    private void cancel(MethodCall call, MethodChannel.Result result) {
-        String taskId = call.argument("taskId");
-        WorkManager.getInstance(context)
-                .cancelWorkById(UUID.fromString(taskId))
-                .getResult()
-                .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
+    if (path == null) {
+      result.error("invalid_call", "Invalid call parameters passed", null);
+      return;
     }
 
-    private void cancelAll(MethodCall call, MethodChannel.Result result) {
-        WorkManager.getInstance(context)
-                .cancelAllWorkByTag(FLUTTER_UPLOAD_WORK_TAG)
-                .getResult()
-                .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
+    if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
+      result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
+      return;
     }
 
-    private void clearUploads(MethodCall call, MethodChannel.Result result) {
-        WorkManager.getInstance(context)
-                .pruneWork()
-                .getResult()
-                .addListener(
-                        () -> {
-                            statusListener.onWorkPruned();
-                            mainExecutor.execute(() -> result.success(null));
-                        },
-                        workManagerExecutor);
+    WorkRequest request =
+        buildRequest(
+            new UploadTask(
+                url,
+                method,
+                Collections.singletonList(new FileItem(path)),
+                headers,
+                Collections.emptyMap(),
+                connectionTimeout,
+                true,
+                tag,
+                allowCellular != null ? allowCellular : true));
+    WorkManager.getInstance(context)
+        .enqueue(request)
+        .getResult()
+        .addListener(
+            () -> {
+              String taskId = request.getId().toString();
+              mainExecutor.execute(
+                  () -> {
+                    result.success(taskId);
+                    statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
+                  });
+            },
+            workManagerExecutor);
+  }
+
+  private void cancel(MethodCall call, MethodChannel.Result result) {
+    String taskId = call.argument("taskId");
+    WorkManager.getInstance(context)
+        .cancelWorkById(UUID.fromString(taskId))
+        .getResult()
+        .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
+  }
+
+  private void cancelAll(MethodCall call, MethodChannel.Result result) {
+    WorkManager.getInstance(context)
+        .cancelAllWorkByTag(FLUTTER_UPLOAD_WORK_TAG)
+        .getResult()
+        .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
+  }
+
+  private void clearUploads(MethodCall call, MethodChannel.Result result) {
+    WorkManager.getInstance(context)
+        .pruneWork()
+        .getResult()
+        .addListener(
+            () -> {
+              statusListener.onWorkPruned();
+              mainExecutor.execute(() -> result.success(null));
+            },
+            workManagerExecutor);
+  }
+
+  private WorkRequest buildRequest(UploadTask task) {
+    Gson gson = new Gson();
+
+    Data.Builder dataBuilder =
+        new Data.Builder()
+            .putString(UploadWorker.ARG_URL, task.getURL())
+            .putString(UploadWorker.ARG_METHOD, task.getMethod())
+            .putInt(UploadWorker.ARG_REQUEST_TIMEOUT, task.getTimeout())
+            .putBoolean(UploadWorker.ARG_BINARY_UPLOAD, task.isBinaryUpload())
+            .putString(UploadWorker.ARG_UPLOAD_REQUEST_TAG, task.getTag());
+
+    List<FileItem> files = task.getFiles();
+
+    String fileItemsJson = gson.toJson(files);
+    dataBuilder.putString(UploadWorker.ARG_FILES, fileItemsJson);
+
+    if (task.getHeaders() != null) {
+      String headersJson = gson.toJson(task.getHeaders());
+      dataBuilder.putString(UploadWorker.ARG_HEADERS, headersJson);
     }
 
-    private WorkRequest buildRequest(UploadTask task) {
-        Gson gson = new Gson();
-
-        Data.Builder dataBuilder =
-                new Data.Builder()
-                        .putString(UploadWorker.ARG_URL, task.getURL())
-                        .putString(UploadWorker.ARG_METHOD, task.getMethod())
-                        .putInt(UploadWorker.ARG_REQUEST_TIMEOUT, task.getTimeout())
-                        .putBoolean(UploadWorker.ARG_BINARY_UPLOAD, task.isBinaryUpload())
-                        .putString(UploadWorker.ARG_UPLOAD_REQUEST_TAG, task.getTag());
-
-        List<FileItem> files = task.getFiles();
-
-        String fileItemsJson = gson.toJson(files);
-        dataBuilder.putString(UploadWorker.ARG_FILES, fileItemsJson);
-
-        if (task.getHeaders() != null) {
-            String headersJson = gson.toJson(task.getHeaders());
-            dataBuilder.putString(UploadWorker.ARG_HEADERS, headersJson);
-        }
-
-        if (task.getParameters() != null) {
-            String parametersJson = gson.toJson(task.getParameters());
-            dataBuilder.putString(UploadWorker.ARG_DATA, parametersJson);
-        }
-
-        Constraints constraints = new Constraints.Builder()
-                .setRequiredNetworkType(task.isAllowCellular() ? NetworkType.CONNECTED : NetworkType.UNMETERED)
-                .build();
-        return new OneTimeWorkRequest.Builder(UploadWorker.class)
-                .setConstraints(constraints)
-                .addTag(FLUTTER_UPLOAD_WORK_TAG)
-                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.SECONDS)
-                .setInputData(dataBuilder.build())
-                .build();
+    if (task.getParameters() != null) {
+      String parametersJson = gson.toJson(task.getParameters());
+      dataBuilder.putString(UploadWorker.ARG_DATA, parametersJson);
     }
+
+    Constraints constraints =
+        new Constraints.Builder()
+            .setRequiredNetworkType(
+                task.isAllowCellular() ? NetworkType.CONNECTED : NetworkType.UNMETERED)
+            .build();
+    return new OneTimeWorkRequest.Builder(UploadWorker.class)
+        .setConstraints(constraints)
+        .addTag(FLUTTER_UPLOAD_WORK_TAG)
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.SECONDS)
+        .setInputData(dataBuilder.build())
+        .build();
+  }
 }

--- a/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
@@ -92,7 +92,11 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     Map<String, String> parameters = call.argument("data");
     Map<String, String> headers = call.argument("headers");
     String tag = call.argument("tag");
-    Boolean allowCellular = call.<Boolean>argument("allowCellular");
+    Boolean allowCellular = call.argument("allowCellular");
+    if (allowCellular == null) {
+      result.error("invalid_flag", "allowCellular must be set", null);
+      return;
+    }
 
     if (method == null) {
       method = "POST";
@@ -113,6 +117,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     for (Map<String, String> file : files) {
       items.add(FileItem.fromJson(file));
     }
+
     WorkRequest request =
         buildRequest(
             new UploadTask(
@@ -124,7 +129,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
                 connectionTimeout,
                 false,
                 tag,
-                allowCellular != null ? allowCellular : true));
+                allowCellular));
 
     WorkManager.getInstance(context)
         .enqueue(request)
@@ -147,7 +152,12 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     String path = call.argument("path");
     Map<String, String> headers = call.argument("headers");
     String tag = call.argument("tag");
-    Boolean allowCellular = call.<Boolean>argument("allowCellular");
+    Boolean allowCellular = call.argument("allowCellular");
+
+    if (allowCellular == null) {
+      result.error("invalid_flag", "allowCellular must be set", null);
+      return;
+    }
 
     if (method == null) {
       method = "POST";
@@ -174,7 +184,8 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
                 connectionTimeout,
                 true,
                 tag,
-                allowCellular != null ? allowCellular : true));
+                allowCellular));
+
     WorkManager.getInstance(context)
         .enqueue(request)
         .getResult()

--- a/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
@@ -1,6 +1,7 @@
 package com.bluechilli.flutteruploader;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.work.BackoffPolicy;
@@ -10,12 +11,15 @@ import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
+
 import com.bluechilli.flutteruploader.plugin.StatusListener;
 import com.google.gson.Gson;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,215 +32,236 @@ import java.util.concurrent.TimeUnit;
 
 public class MethodCallHandlerImpl implements MethodCallHandler {
 
-  /** The generic {@link WorkManager} tag which matches any upload. */
-  public static final String FLUTTER_UPLOAD_WORK_TAG = "flutter_upload_task";
+    /**
+     * The generic {@link WorkManager} tag which matches any upload.
+     */
+    public static final String FLUTTER_UPLOAD_WORK_TAG = "flutter_upload_task";
 
-  private final Context context;
+    private final Context context;
 
-  private final int connectionTimeout;
+    private final int connectionTimeout;
 
-  @NonNull private final StatusListener statusListener;
+    @NonNull
+    private final StatusListener statusListener;
 
-  private final Executor workManagerExecutor = Executors.newSingleThreadExecutor();
-  private final Executor mainExecutor;
+    private final Executor workManagerExecutor = Executors.newSingleThreadExecutor();
+    private final Executor mainExecutor;
 
-  private static final List<String> VALID_HTTP_METHODS = Arrays.asList("POST", "PUT", "PATCH");
+    private static final List<String> VALID_HTTP_METHODS = Arrays.asList("POST", "PUT", "PATCH");
 
-  MethodCallHandlerImpl(Context context, int timeout, @NonNull StatusListener listener) {
-    mainExecutor = ContextCompat.getMainExecutor(context);
-    this.context = context;
-    this.connectionTimeout = timeout;
-    this.statusListener = listener;
-  }
-
-  @Override
-  public void onMethodCall(MethodCall call, @NonNull Result result) {
-    switch (call.method) {
-      case "setBackgroundHandler":
-        setBackgroundHandler(call, result);
-        break;
-      case "enqueue":
-        enqueue(call, result);
-        break;
-      case "enqueueBinary":
-        enqueueBinary(call, result);
-        break;
-      case "cancel":
-        cancel(call, result);
-        break;
-      case "cancelAll":
-        cancelAll(call, result);
-        break;
-      case "clearUploads":
-        clearUploads(call, result);
-        break;
-      default:
-        result.notImplemented();
-        break;
-    }
-  }
-
-  void setBackgroundHandler(MethodCall call, MethodChannel.Result result) {
-    Long callbackHandle = call.argument("callbackHandle");
-    if (callbackHandle != null) {
-      SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle);
+    MethodCallHandlerImpl(Context context, int timeout, @NonNull StatusListener listener) {
+        mainExecutor = ContextCompat.getMainExecutor(context);
+        this.context = context;
+        this.connectionTimeout = timeout;
+        this.statusListener = listener;
     }
 
-    result.success(null);
-  }
-
-  private void enqueue(MethodCall call, MethodChannel.Result result) {
-    String url = call.argument("url");
-    String method = call.argument("method");
-    List<Map<String, String>> files = call.argument("files");
-    Map<String, String> parameters = call.argument("data");
-    Map<String, String> headers = call.argument("headers");
-    String tag = call.argument("tag");
-
-    if (method == null) {
-      method = "POST";
+    @Override
+    public void onMethodCall(MethodCall call, @NonNull Result result) {
+        switch (call.method) {
+            case "setBackgroundHandler":
+                setBackgroundHandler(call, result);
+                break;
+            case "enqueue":
+                enqueue(call, result);
+                break;
+            case "enqueueBinary":
+                enqueueBinary(call, result);
+                break;
+            case "cancel":
+                cancel(call, result);
+                break;
+            case "cancelAll":
+                cancelAll(call, result);
+                break;
+            case "clearUploads":
+                clearUploads(call, result);
+                break;
+            default:
+                result.notImplemented();
+                break;
+        }
     }
 
-    if (files == null || files.isEmpty()) {
-      result.error("invalid_call", "Invalid call parameters passed", null);
-      return;
+    void setBackgroundHandler(MethodCall call, MethodChannel.Result result) {
+        Long callbackHandle = call.argument("callbackHandle");
+        if (callbackHandle != null) {
+            SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle);
+        }
+
+        result.success(null);
     }
 
-    if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
-      result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
-      return;
+    private void enqueue(MethodCall call, MethodChannel.Result result) {
+        String url = call.argument("url");
+        String method = call.argument("method");
+        List<Map<String, String>> files = call.argument("files");
+        Map<String, String> parameters = call.argument("data");
+        Map<String, String> headers = call.argument("headers");
+        String tag = call.argument("tag");
+        Boolean allowCellular = call.<Boolean>argument("allowCellular");
+
+        if (method == null) {
+            method = "POST";
+        }
+
+        if (files == null || files.isEmpty()) {
+            result.error("invalid_call", "Invalid call parameters passed", null);
+            return;
+        }
+
+        if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
+            result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
+            return;
+        }
+
+        List<FileItem> items = new ArrayList<>();
+
+        for (Map<String, String> file : files) {
+            items.add(FileItem.fromJson(file));
+        }
+        WorkRequest request =
+                buildRequest(
+                        new UploadTask(
+                                url,
+                                method,
+                                items,
+                                headers,
+                                parameters,
+                                connectionTimeout,
+                                false,
+                                tag,
+                                allowCellular != null ? allowCellular : true
+                        )
+                );
+
+        WorkManager.getInstance(context)
+                .enqueue(request)
+                .getResult()
+                .addListener(
+                        () -> {
+                            String taskId = request.getId().toString();
+                            mainExecutor.execute(
+                                    () -> {
+                                        result.success(taskId);
+                                        statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
+                                    });
+                        },
+                        workManagerExecutor);
     }
 
-    List<FileItem> items = new ArrayList<>();
+    private void enqueueBinary(MethodCall call, MethodChannel.Result result) {
+        String url = call.argument("url");
+        String method = call.argument("method");
+        String path = call.argument("path");
+        Map<String, String> headers = call.argument("headers");
+        String tag = call.argument("tag");
+        Boolean allowCellular = call.<Boolean>argument("allowCellular");
 
-    for (Map<String, String> file : files) {
-      items.add(FileItem.fromJson(file));
+        if (method == null) {
+            method = "POST";
+        }
+
+        if (path == null) {
+            result.error("invalid_call", "Invalid call parameters passed", null);
+            return;
+        }
+
+        if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
+            result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
+            return;
+        }
+
+        WorkRequest request =
+                buildRequest(
+                        new UploadTask(
+                                url,
+                                method,
+                                Collections.singletonList(new FileItem(path)),
+                                headers,
+                                Collections.emptyMap(),
+                                connectionTimeout,
+                                true,
+                                tag,
+                                allowCellular != null ? allowCellular : true
+                        )
+                );
+        WorkManager.getInstance(context)
+                .enqueue(request)
+                .getResult()
+                .addListener(
+                        () -> {
+                            String taskId = request.getId().toString();
+                            mainExecutor.execute(
+                                    () -> {
+                                        result.success(taskId);
+                                        statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
+                                    });
+                        },
+                        workManagerExecutor);
     }
 
-    WorkRequest request =
-        buildRequest(
-            new UploadTask(url, method, items, headers, parameters, connectionTimeout, false, tag));
-    WorkManager.getInstance(context)
-        .enqueue(request)
-        .getResult()
-        .addListener(
-            () -> {
-              String taskId = request.getId().toString();
-              mainExecutor.execute(
-                  () -> {
-                    result.success(taskId);
-                    statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
-                  });
-            },
-            workManagerExecutor);
-  }
-
-  private void enqueueBinary(MethodCall call, MethodChannel.Result result) {
-    String url = call.argument("url");
-    String method = call.argument("method");
-    String path = call.argument("path");
-    Map<String, String> headers = call.argument("headers");
-    String tag = call.argument("tag");
-
-    if (method == null) {
-      method = "POST";
+    private void cancel(MethodCall call, MethodChannel.Result result) {
+        String taskId = call.argument("taskId");
+        WorkManager.getInstance(context)
+                .cancelWorkById(UUID.fromString(taskId))
+                .getResult()
+                .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
     }
 
-    if (path == null) {
-      result.error("invalid_call", "Invalid call parameters passed", null);
-      return;
+    private void cancelAll(MethodCall call, MethodChannel.Result result) {
+        WorkManager.getInstance(context)
+                .cancelAllWorkByTag(FLUTTER_UPLOAD_WORK_TAG)
+                .getResult()
+                .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
     }
 
-    if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
-      result.error("invalid_method", "Method must be either POST | PUT | PATCH", null);
-      return;
+    private void clearUploads(MethodCall call, MethodChannel.Result result) {
+        WorkManager.getInstance(context)
+                .pruneWork()
+                .getResult()
+                .addListener(
+                        () -> {
+                            statusListener.onWorkPruned();
+                            mainExecutor.execute(() -> result.success(null));
+                        },
+                        workManagerExecutor);
     }
 
-    WorkRequest request =
-        buildRequest(
-            new UploadTask(
-                url,
-                method,
-                Collections.singletonList(new FileItem(path)),
-                headers,
-                Collections.emptyMap(),
-                connectionTimeout,
-                true,
-                tag));
-    WorkManager.getInstance(context)
-        .enqueue(request)
-        .getResult()
-        .addListener(
-            () -> {
-              String taskId = request.getId().toString();
-              mainExecutor.execute(
-                  () -> {
-                    result.success(taskId);
-                    statusListener.onUpdateProgress(taskId, UploadStatus.ENQUEUED, 0);
-                  });
-            },
-            workManagerExecutor);
-  }
+    private WorkRequest buildRequest(UploadTask task) {
+        Gson gson = new Gson();
 
-  private void cancel(MethodCall call, MethodChannel.Result result) {
-    String taskId = call.argument("taskId");
-    WorkManager.getInstance(context)
-        .cancelWorkById(UUID.fromString(taskId))
-        .getResult()
-        .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
-  }
+        Data.Builder dataBuilder =
+                new Data.Builder()
+                        .putString(UploadWorker.ARG_URL, task.getURL())
+                        .putString(UploadWorker.ARG_METHOD, task.getMethod())
+                        .putInt(UploadWorker.ARG_REQUEST_TIMEOUT, task.getTimeout())
+                        .putBoolean(UploadWorker.ARG_BINARY_UPLOAD, task.isBinaryUpload())
+                        .putString(UploadWorker.ARG_UPLOAD_REQUEST_TAG, task.getTag());
 
-  private void cancelAll(MethodCall call, MethodChannel.Result result) {
-    WorkManager.getInstance(context)
-        .cancelAllWorkByTag(FLUTTER_UPLOAD_WORK_TAG)
-        .getResult()
-        .addListener(() -> mainExecutor.execute(() -> result.success(null)), workManagerExecutor);
-  }
+        List<FileItem> files = task.getFiles();
 
-  private void clearUploads(MethodCall call, MethodChannel.Result result) {
-    WorkManager.getInstance(context)
-        .pruneWork()
-        .getResult()
-        .addListener(
-            () -> {
-              statusListener.onWorkPruned();
-              mainExecutor.execute(() -> result.success(null));
-            },
-            workManagerExecutor);
-  }
+        String fileItemsJson = gson.toJson(files);
+        dataBuilder.putString(UploadWorker.ARG_FILES, fileItemsJson);
 
-  private WorkRequest buildRequest(UploadTask task) {
-    Gson gson = new Gson();
+        if (task.getHeaders() != null) {
+            String headersJson = gson.toJson(task.getHeaders());
+            dataBuilder.putString(UploadWorker.ARG_HEADERS, headersJson);
+        }
 
-    Data.Builder dataBuilder =
-        new Data.Builder()
-            .putString(UploadWorker.ARG_URL, task.getURL())
-            .putString(UploadWorker.ARG_METHOD, task.getMethod())
-            .putInt(UploadWorker.ARG_REQUEST_TIMEOUT, task.getTimeout())
-            .putBoolean(UploadWorker.ARG_BINARY_UPLOAD, task.isBinaryUpload())
-            .putString(UploadWorker.ARG_UPLOAD_REQUEST_TAG, task.getTag());
+        if (task.getParameters() != null) {
+            String parametersJson = gson.toJson(task.getParameters());
+            dataBuilder.putString(UploadWorker.ARG_DATA, parametersJson);
+        }
 
-    List<FileItem> files = task.getFiles();
-
-    String fileItemsJson = gson.toJson(files);
-    dataBuilder.putString(UploadWorker.ARG_FILES, fileItemsJson);
-
-    if (task.getHeaders() != null) {
-      String headersJson = gson.toJson(task.getHeaders());
-      dataBuilder.putString(UploadWorker.ARG_HEADERS, headersJson);
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(task.isAllowCellular() ? NetworkType.CONNECTED : NetworkType.UNMETERED)
+                .build();
+        return new OneTimeWorkRequest.Builder(UploadWorker.class)
+                .setConstraints(constraints)
+                .addTag(FLUTTER_UPLOAD_WORK_TAG)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.SECONDS)
+                .setInputData(dataBuilder.build())
+                .build();
     }
-
-    if (task.getParameters() != null) {
-      String parametersJson = gson.toJson(task.getParameters());
-      dataBuilder.putString(UploadWorker.ARG_DATA, parametersJson);
-    }
-
-    return new OneTimeWorkRequest.Builder(UploadWorker.class)
-        .setConstraints(
-            new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
-        .addTag(FLUTTER_UPLOAD_WORK_TAG)
-        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.SECONDS)
-        .setInputData(dataBuilder.build())
-        .build();
-  }
 }

--- a/android/src/main/java/com/bluechilli/flutteruploader/UploadTask.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/UploadTask.java
@@ -14,6 +14,7 @@ public class UploadTask {
   private int requestTimeoutInSeconds;
   private boolean binaryUpload;
   private String tag;
+  private boolean allowCellular;
 
   public UploadTask(
       String url,
@@ -23,7 +24,9 @@ public class UploadTask {
       Map<String, String> data,
       int requestTimeoutInSeconds,
       boolean binaryUpload,
-      String tag) {
+      String tag,
+      boolean allowCellular
+      ) {
     this.url = url;
     this.method = method;
     this.files = files;
@@ -32,6 +35,7 @@ public class UploadTask {
     this.requestTimeoutInSeconds = requestTimeoutInSeconds;
     this.binaryUpload = binaryUpload;
     this.tag = tag;
+    this.allowCellular = allowCellular;
   }
 
   public String getURL() {
@@ -68,5 +72,9 @@ public class UploadTask {
 
   public String getTag() {
     return tag;
+  }
+
+  public boolean isAllowCellular() {
+    return allowCellular;
   }
 }

--- a/android/src/main/java/com/bluechilli/flutteruploader/UploadTask.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/UploadTask.java
@@ -25,8 +25,7 @@ public class UploadTask {
       int requestTimeoutInSeconds,
       boolean binaryUpload,
       String tag,
-      boolean allowCellular
-      ) {
+      boolean allowCellular) {
     this.url = url;
     this.method = method;
     this.files = files;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -117,6 +117,8 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   int _currentIndex = 0;
 
+  bool allowCellular = true;
+
   @override
   void initState() {
     super.initState();
@@ -139,6 +141,16 @@ class _AppState extends State<App> {
       initializationSettings,
       onSelectNotification: (payload) async {},
     );
+
+    SharedPreferences.getInstance()
+        .then((sp) => sp.getBool('allowCellular') ?? true)
+        .then((result) {
+      if (mounted) {
+        setState(() {
+          allowCellular = result;
+        });
+      }
+    });
   }
 
   @override
@@ -149,6 +161,24 @@ class _AppState extends State<App> {
         primarySwatch: Colors.blue,
       ),
       home: Scaffold(
+        appBar: AppBar(
+          actions: [
+            IconButton(
+              icon: Icon(allowCellular
+                  ? Icons.signal_cellular_connected_no_internet_4_bar
+                  : Icons.wifi_outlined),
+              onPressed: () async {
+                final sp = await SharedPreferences.getInstance();
+                await sp.setBool('allowCellular', !allowCellular);
+                if (mounted) {
+                  setState(() {
+                    allowCellular = !allowCellular;
+                  });
+                }
+              },
+            ),
+          ],
+        ),
         body: _currentIndex == 0
             ? UploadScreen(
                 uploader: _uploader,

--- a/example/lib/upload_screen.dart
+++ b/example/lib/upload_screen.dart
@@ -199,16 +199,19 @@ class _UploadScreenState extends State<UploadScreen> {
   void _handleFileUpload(List<String?> paths) async {
     final prefs = await SharedPreferences.getInstance();
     final binary = prefs.getBool('binary') ?? false;
+    final allowCellular = prefs.getBool('allowCellular') ?? true;
 
     await widget.uploader.enqueue(_buildUpload(
       binary,
       paths.whereType<String>().toList(),
+      allowCellular,
     ));
 
     widget.onUploadStarted();
   }
 
-  Upload _buildUpload(bool binary, List<String> paths) {
+  Upload _buildUpload(bool binary, List<String> paths,
+      [bool allowCellular = true]) {
     final tag = 'upload';
 
     var url = binary
@@ -225,6 +228,7 @@ class _UploadScreenState extends State<UploadScreen> {
         path: paths.first,
         method: UploadMethod.POST,
         tag: tag,
+        allowCellular: allowCellular,
       );
     } else {
       return MultipartFormDataUpload(
@@ -233,6 +237,7 @@ class _UploadScreenState extends State<UploadScreen> {
         files: paths.map((e) => FileItem(path: e, field: 'file')).toList(),
         method: UploadMethod.POST,
         tag: tag,
+        allowCellular: allowCellular,
       );
     }
   }

--- a/ios/Classes/SwiftFlutterUploaderPlugin.swift
+++ b/ios/Classes/SwiftFlutterUploaderPlugin.swift
@@ -123,7 +123,10 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let allowCellular = args["allowCellular"] as? Bool ?? true
+        guard let allowCellular = args["allowCellular"] as? Bool else {
+            result(FlutterError(code: "invalid_flag", message: "allowCellular must be set", details: nil))
+            return
+        }
 
         uploadTaskWithURLWithCompletion(
             url: url,
@@ -177,7 +180,10 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let allowCellular: Bool = args["allowCellular"] as? Bool ?? true
+        guard let allowCellular = args["allowCellular"] as? Bool else {
+            result(FlutterError(code: "invalid_flag", message: "allowCellular must be set", details: nil))
+            return
+        }
 
         binaryUploadTaskWithURLWithCompletion(url: url, file: fileUrl, method: method, headers: headers, tag: tag, allowCellular: allowCellular, completion: { (task, error) in
             if error != nil {

--- a/ios/Classes/SwiftFlutterUploaderPlugin.swift
+++ b/ios/Classes/SwiftFlutterUploaderPlugin.swift
@@ -123,6 +123,8 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
+        let allowCellular = args["allowCellular"] as? Bool ?? true
+
         uploadTaskWithURLWithCompletion(
             url: url,
             files: files,
@@ -130,6 +132,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             headers: headers,
             parameters: data,
             tag: tag,
+            allowCellular: allowCellular,
             completion: { (task, error) in
                 if error != nil {
                     result(error!)
@@ -174,7 +177,9 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        binaryUploadTaskWithURLWithCompletion(url: url, file: fileUrl, method: method, headers: headers, tag: tag, completion: { (task, error) in
+        let allowCellular: Bool = args["allowCellular"] as? Bool ?? true
+
+        binaryUploadTaskWithURLWithCompletion(url: url, file: fileUrl, method: method, headers: headers, tag: tag, allowCellular: allowCellular, completion: { (task, error) in
             if error != nil {
                 result(error!)
             } else if let uploadTask = task {
@@ -203,6 +208,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
                                                        method: String,
                                                        headers: [String: Any?]?,
                                                        tag: String?,
+                                                       allowCellular: Bool,
                                                        completion completionHandler:@escaping (URLSessionUploadTask?, FlutterError?) -> Void) {
         let request = NSMutableURLRequest(url: url)
         request.httpMethod = method
@@ -214,7 +220,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             }
         }
 
-        completionHandler(self.urlSessionUploader.enqueueUploadTask(request as URLRequest, path: file.path), nil)
+        completionHandler(self.urlSessionUploader.enqueueUploadTask(request as URLRequest, path: file.path, wifiOnly: !allowCellular), nil)
     }
 
     private func uploadTaskWithURLWithCompletion(
@@ -224,6 +230,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
         headers: [String: Any?]?,
         parameters data: [String: Any?]?,
         tag: String?,
+        allowCellular: Bool,
         completion completionHandler:@escaping (URLSessionUploadTask?, FlutterError?) -> Void) {
         var flutterError: FlutterError?
         let fileManager = FileManager.default
@@ -290,7 +297,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        self.makeRequest(path, url, method, headers, formData.contentType, formData.contentLength, completion: { (task, error) in
+        self.makeRequest(path, url, method, headers, formData.contentType, formData.contentLength, allowCellular: allowCellular, completion: { (task, error) in
             completionHandler(task, error)
         })
     }
@@ -302,6 +309,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
         _ headers: [String: Any?]? = [:],
         _ contentType: String,
         _ contentLength: UInt64,
+        allowCellular: Bool,
         completion completionHandler: (URLSessionUploadTask?, FlutterError?) -> Void) {
         let request = NSMutableURLRequest(url: url)
         request.httpMethod = method
@@ -324,7 +332,7 @@ public class SwiftFlutterUploaderPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        completionHandler(urlSessionUploader.enqueueUploadTask(request as URLRequest, path: path), nil)
+        completionHandler(urlSessionUploader.enqueueUploadTask(request as URLRequest, path: path, wifiOnly: !allowCellular), nil)
     }
 }
 

--- a/ios/Classes/URLSessionUploader.swift
+++ b/ios/Classes/URLSessionUploader.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct Keys {
     static let backgroundSessionIdentifier = "chillisource.flutter_uploader.upload.background"
+    static let wifiBackgroundSessionIdentifier = "chillisource.flutter_uploader.upload.background.wifi"
     fileprivate static let maximumConcurrentTask = "FUMaximumConnectionsPerHost"
     fileprivate static let maximumConcurrentUploadOperation = "FUMaximumUploadOperation"
 
@@ -20,6 +21,7 @@ class URLSessionUploader: NSObject {
     static let shared = URLSessionUploader()
 
     var session: URLSession?
+    var wifiSession: URLSession?
     let queue = OperationQueue()
 
     // Accessing uploadedData & runningTaskById will require exclusive access
@@ -43,12 +45,13 @@ class URLSessionUploader: NSObject {
         delegates.append(delegate)
     }
 
-    func enqueueUploadTask(_ request: URLRequest, path: String) -> URLSessionUploadTask? {
-        guard let session = self.session else {
+    func enqueueUploadTask(_ request: URLRequest, path: String, wifiOnly: Bool) -> URLSessionUploadTask? {
+        guard let session = self.session,
+              let wifiSession = self.wifiSession else {
             return nil
         }
 
-        let uploadTask = session.uploadTask(with: request as URLRequest, fromFile: URL(fileURLWithPath: path))
+        let uploadTask = (wifiOnly ? wifiSession : session).uploadTask(with: request as URLRequest, fromFile: URL(fileURLWithPath: path))
 
         // Create a random UUID as task description (& ID).
         uploadTask.taskDescription = UUID().uuidString
@@ -138,6 +141,14 @@ class URLSessionUploader: NSObject {
 
         self.queue.maxConcurrentOperationCount = maxUploadOperation.intValue
 
+        // configure session for wifi only uploads
+        let wifiConfiguration = URLSessionConfiguration.background(withIdentifier: Keys.wifiBackgroundSessionIdentifier)
+        wifiConfiguration.httpMaximumConnectionsPerHost = maxConcurrentTasks.intValue
+        wifiConfiguration.timeoutIntervalForRequest = URLSessionUploader.determineTimeout()
+        wifiConfiguration.allowsCellularAccess = false
+        self.wifiSession = URLSession(configuration: wifiConfiguration, delegate: self, delegateQueue: queue)
+
+        // configure regular session
         let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: Keys.backgroundSessionIdentifier)
         sessionConfiguration.httpMaximumConnectionsPerHost = maxConcurrentTasks.intValue
         sessionConfiguration.timeoutIntervalForRequest = URLSessionUploader.determineTimeout()

--- a/ios/Classes/URLSessionUploader.swift
+++ b/ios/Classes/URLSessionUploader.swift
@@ -51,7 +51,11 @@ class URLSessionUploader: NSObject {
             return nil
         }
 
-        let uploadTask = (wifiOnly ? wifiSession : session).uploadTask(with: request as URLRequest, fromFile: URL(fileURLWithPath: path))
+        let activeSession = wifiOnly ? wifiSession : session
+        let uploadTask = activeSession.uploadTask(
+                with: request as URLRequest,
+                fromFile: URL(fileURLWithPath: path)
+        )
 
         // Create a random UUID as task description (& ID).
         uploadTask.taskDescription = UUID().uuidString

--- a/ios/Classes/UploadTask.swift
+++ b/ios/Classes/UploadTask.swift
@@ -16,11 +16,13 @@ struct UploadTask {
     let status: UploadTaskStatus
     let progress: Int
     let tag: String?
+    let allowCellular: Bool
 
-    init(taskId: String, status: UploadTaskStatus, progress: Int, tag: String? = nil) {
+    init(taskId: String, status: UploadTaskStatus, progress: Int, tag: String? = nil, allowCellular: Bool = true) {
         self.taskId = taskId
         self.status = status
         self.progress = progress
         self.tag = tag
+        self.allowCellular = allowCellular
     }
 }

--- a/lib/src/flutter_uploader.dart
+++ b/lib/src/flutter_uploader.dart
@@ -107,6 +107,7 @@ class FlutterUploader {
         'headers': upload.headers,
         'data': upload.data,
         'tag': upload.tag,
+        'allowCellular': upload.allowCellular,
       }))!;
     }
     if (upload is RawUpload) {
@@ -115,7 +116,8 @@ class FlutterUploader {
         'method': describeEnum(upload.method),
         'path': upload.path,
         'headers': upload.headers,
-        'tag': upload.tag
+        'tag': upload.tag,
+        'allowCellular': upload.allowCellular,
       }))!;
     }
 

--- a/lib/src/upload.dart
+++ b/lib/src/upload.dart
@@ -9,6 +9,7 @@ abstract class Upload {
     required this.method,
     this.headers = const <String, String>{},
     this.tag,
+    this.allowCellular = true,
   });
 
   /// Upload link
@@ -22,6 +23,10 @@ abstract class Upload {
 
   /// Name of the upload request (only used on Android)
   final String? tag;
+
+  /// If uploads are allowed to use cellular connections
+  /// Defaults to true. If false, uploads will only use wifi connections
+  final bool allowCellular;
 }
 
 /// Standard RFC 2388 multipart/form-data upload.
@@ -36,12 +41,14 @@ class MultipartFormDataUpload extends Upload {
     String? tag,
     this.files,
     this.data,
+    bool allowCellular = true,
   })  : assert(files != null || data != null),
         super(
           url: url,
           method: method,
           headers: headers,
           tag: tag,
+          allowCellular: allowCellular,
         ) {
     // Need to specify either files or data.
     assert(files!.isNotEmpty || data!.isNotEmpty);
@@ -63,11 +70,13 @@ class RawUpload extends Upload {
     Map<String, String>? headers,
     String? tag,
     this.path,
+    bool allowCellular = true,
   }) : super(
           url: url,
           method: method,
           headers: headers,
           tag: tag,
+          allowCellular: allowCellular,
         );
 
   /// single file to upload

--- a/test/flutter_uploader_test.dart
+++ b/test/flutter_uploader_test.dart
@@ -73,7 +73,7 @@ void main() {
           isMethodCall('setBackgroundHandler', arguments: <String, dynamic>{
             'callbackHandle':
                 PluginUtilities.getCallbackHandle(tmpBackgroundHandler)!
-                    .toRawHandle(),
+                    .toRawHandle()
           }),
         ]);
       });
@@ -92,6 +92,13 @@ void main() {
         tag: 'tag1',
       );
 
+      test('allowCellular has default value of true', () async {
+        methodChannel.setMockMethodCallHandler((call) async {
+          expect(call.arguments['allowCellular'] as bool?, isTrue);
+          return 'allowCellular';
+        });
+        expect(await uploader.enqueue(sampleUpload), 'allowCellular');
+      });
       test('returns the task id', () async {
         mockResponse = 'TASK123';
 

--- a/test/flutter_uploader_test.dart
+++ b/test/flutter_uploader_test.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_uploader/flutter_uploader.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_uploader/flutter_uploader.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -123,6 +123,7 @@ void main() {
               'data1': 'value1',
             },
             'tag': 'tag1',
+            'allowCellular': true,
           }),
         ]);
       });
@@ -157,6 +158,7 @@ void main() {
               'header1': 'value1',
             },
             'tag': 'tag1',
+            'allowCellular': true,
           }),
         ]);
       });


### PR DESCRIPTION
+ Add flag to the Dart interface and pass it into
the method channel when enqueuing jobs

+ Read `allowCellular` flag from method channel
arguments when queueing uploads in iOS. 
+ Add a second session and session configuration
to `URLSessionUploader` that sets `allowCellularAccess` to `false`. The sessions are 
supposed to be long lived objects, so we construct both of them only once and keep them around.
+ Add switch to the actual creation of the upload task
that respects the `allowCellular` flag of the job and
chooses the correct session to schedule the upload.