### PR TITLE
#189 Do not persist nil values in result database

### DIFF
--- a/ios/Classes/UploadResultDatabase.swift
+++ b/ios/Classes/UploadResultDatabase.swift
@@ -59,7 +59,7 @@ class UploadResultDatabase: UploaderDelegate {
         results.append([
             Key.taskId: taskId,
             Key.status: UploadTaskStatus.completed.rawValue,
-            Key.message: message ?? NSNull(),
+            Key.message: message ?? "",
             Key.statusCode: statusCode,
             Key.headers: headers
         ])


### PR DESCRIPTION
`CFNull` is not a valid value in the plist and leads to 
an error when attempting to persist it in the 
`UploadResultDatabase`.
Instead of writing `CFNull` if the `message` is `nil` 
we write an empty string.
