### PR TITLE
Fix initial situation, when there is no plist

### DIFF
--- a/ios/Classes/UploadResultDatabase.swift
+++ b/ios/Classes/UploadResultDatabase.swift
@@ -13,7 +13,7 @@ class UploadResultDatabase: UploaderDelegate {
     static let shared = UploadResultDatabase()
 
     private init() {
-        if let url = resultsPListURL, let plist = try? loadPropertyList(url) {
+        if let url = resultsPListURL, let plist = loadPropertyList(url) {
             for result in plist {
                 if let map = result as? [String: Any] {
                     self.results.append(map)
@@ -97,9 +97,8 @@ class UploadResultDatabase: UploaderDelegate {
         try plistData.write(to: plistURL)
     }
 
-    private func loadPropertyList(_ plistURL: URL) throws -> [Any] {
-        let data = try Data(contentsOf: plistURL)
-        guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [Any] else {
+    private func loadPropertyList(_ plistURL: URL) -> [Any] {
+        guard let data = try? Data(contentsOf: plistURL), let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [Any] else {
             return []
         }
         return plist


### PR DESCRIPTION
If there is no property list (e.g. first start) an empty list should be returned and will correctly be handled in `init` or the other solution could be that there is a try & catch like e.g. https://github.com/fluttercommunity/flutter_uploader/blob/d660a09b1ace1c90c71dd52c7f9b58a23ae85be1/ios/Classes/UploadResultDatabase.swift#L47


This is the issue you face, when you have the debugger attached in Xcode: 

```
thread #1 (closed), queue = 'com.apple.main-thread', stop reason = breakpoint 2.1
frame #0: 0x000000018933da84 libswiftCore.dylibswift_willThrow frame #1: 0x0000000188ed7c6c libswiftFoundation.dylib__C.NSData.__allocating_init(contentsOf: Foundation.URL, options: __C.NSDataReadingOptions) throws -> __C.NSData + 176
frame #2 (closed): 0x0000000188ed7b7c libswiftFoundation.dylib`Foundation.Data.init(contentsOf: __shared Foundation.URL, options: __C.NSDataReadingOptions) throws -> Foundation.Data + 96

frame #3 (closed): 0x0000000104453ecc flutter_uploaderUploadResultDatabase.loadPropertyList(plistURL="file:///var/mobile/Containers/Data/Application/8DADF6E9-E4E7-407E-AF8E-8DBD9A096138/Library/Application%20Support/flutter_uploader-results.plist", self=0x0000000283fbec60) at UploadResultDatabase.swift:101:24 frame #4: 0x0000000104451658 flutter_uploaderUploadResultDatabase.(self=0x0000000283fbec60).init() at UploadResultDatabase.swift:16:56
frame #5 (closed): 0x00000001044513f8 flutter_uploaderUploadResultDatabase.__allocating_init() at UploadResultDatabase.swift:0 frame #6: 0x00000001044513b4 flutter_uploaderone-time initialization function for shared at UploadResultDatabase.swift:13:25
frame #7 (closed): 0x0000000106a11de0 libdispatch.dylib_dispatch_client_callout + 20 frame #8: 0x0000000106a13998 libdispatch.dylib_dispatch_once_callout + 136
frame #9 (closed): 0x000000018937197c libswiftCore.dylibswift_once + 48 frame #10: 0x0000000104451444 flutter_uploaderUploadResultDatabase.shared.unsafeMutableAddressor at UploadResultDatabase.swift:13:16
frame #11 (closed): 0x0000000104459634 flutter_uploaderURLSessionUploader.().init() at URLSessionUploader.swift:123:47 frame #12: 0x000000010445a44c flutter_uploader@objc URLSessionUploader.().init() at :0
frame #13 (closed): 0x00000001044566a4 flutter_uploaderURLSessionUploader.__allocating_init() at URLSessionUploader.swift:0 frame #14: 0x0000000104456670 flutter_uploaderone-time initialization function for shared at URLSessionUploader.swift:21:25
frame #15 (closed): 0x0000000106a11de0 libdispatch.dylib_dispatch_client_callout + 20 frame #16: 0x0000000106a13998 libdispatch.dylibdispatch_once_callout + 136
frame #17 (closed): 0x000000018937197c libswiftCore.dylibswift_once + 48 frame #18: 0x00000001044566ec flutter_uploaderURLSessionUploader.shared.unsafeMutableAddressor at URLSessionUploader.swift:21:16
frame #19 (closed): 0x0000000104443b58 flutter_uploaderSwiftFlutterUploaderPlugin.init(channel=0x000000028315a610, progressEventChannel=0x0000000283fbffe0, resultEventChannel=0x0000000283fbf9c0) at SwiftFlutterUploaderPlugin.swift:15:49 frame #20: 0x0000000104443890 flutter_uploaderSwiftFlutterUploaderPlugin.__allocating_init(:progressEventChannel:resultEventChannel:) at SwiftFlutterUploaderPlugin.swift:0
frame #21 (closed): 0x00000001044435d8 flutter_uploaderstatic SwiftFlutterUploaderPlugin.register(registrar=0x0000000283fbec20, self=flutter_uploader.SwiftFlutterUploaderPlugin) at SwiftFlutterUploaderPlugin.swift:33:24 frame #22: 0x00000001044438e8 flutter_uploader@objc static SwiftFlutterUploaderPlugin.register(with:) at :0
frame #23 (closed): 0x000000010443b3b4 flutter_uploader+[FlutterUploaderPlugin registerWithRegistrar:](self=FlutterUploaderPlugin, _cmd="registerWithRegistrar:", registrar=0x0000000283fbec20) at FlutterUploaderPlugin.m:11:3 frame #24: 0x00000001026d39e8 Runner+[GeneratedPluginRegistrant registerWithRegistry:](self=GeneratedPluginRegistrant, cmd="registerWithRegistry:", registry=0x000000028319cea0) at GeneratedPluginRegistrant.m:160:3
frame #25 (closed): 0x00000001026d5cd8 RunnerAppDelegate.application(application=0x000000012fe05720, launchOptions=nil, self=0x000000028319cea0) at AppDelegate.swift:40:35 frame #26: 0x00000001026d67c8 Runner@objc AppDelegate.application(:didFinishLaunchingWithOptions:) at :0
frame #27 (closed): 0x0000000187e42980 UIKitCore-[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 360 frame #28: 0x0000000187e44414 UIKitCore-[UIApplication _callInitializationDelegatesWithActions:forCanvas:payload:fromOriginatingProcess:] + 3504
frame #29 (closed): 0x0000000187e4a560 UIKitCore-[UIApplication _runWithMainScene:transitionContext:completion:] + 1244 frame #30: 0x000000018749e1a4 UIKitCore-[_UISceneLifecycleMultiplexer completeApplicationLaunchWithFBSScene:transitionContext:] + 152
frame #31 (closed): 0x0000000187a07458 UIKitCore_UIScenePerformActionsWithLifecycleActionMask + 104 frame #32: 0x000000018749ed3c UIKitCore__101-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]_block_invoke + 224
frame #33 (closed): 0x000000018749e7fc UIKitCore-[_UISceneLifecycleMultiplexer _performBlock:withApplicationOfDeactivationReasons:fromReasons:] + 484 frame #34: 0x000000018749eb4c UIKitCore-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:] + 768
frame #35 (closed): 0x000000018749e388 UIKitCore-[_UISceneLifecycleMultiplexer uiScene:transitionedFromState:withTransitionContext:] + 340 frame #36: 0x00000001874a68cc UIKitCore__186-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:]_block_invoke + 196
frame #37 (closed): 0x0000000187914e84 UIKitCore+[BSAnimationSettings(UIKit) tryAnimatingWithSettings:actions:completion:] + 892 frame #38: 0x0000000187a20268 UIKitCore_UISceneSettingsDiffActionPerformChangesWithTransitionContext + 276
frame #39 (closed): 0x00000001874a65c4 UIKitCore-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:] + 384 frame #40: 0x00000001872ce4ac UIKitCore__64-[UIScene scene:didUpdateWithDiff:transitionContext:completion:]_block_invoke + 776
frame #41 (closed): 0x00000001872cce2c UIKitCore-[UIScene _emitSceneSettingsUpdateResponseForCompletion:afterSceneUpdateWork:] + 256 frame #42: 0x00000001872ce0d4 UIKitCore-[UIScene scene:didUpdateWithDiff:transitionContext:completion:] + 248
frame #43 (closed): 0x0000000187e48700 UIKitCore-[UIApplication workspace:didCreateScene:withTransitionContext:completion:] + 572 frame #44: 0x000000018793e4e4 UIKitCore-[UIApplicationSceneClientAgent scene:didInitializeWithEvent:completion:] + 388
frame #45 (closed): 0x0000000194a275d8 FrontBoardServices-[FBSScene _callOutQueue_agent_didCreateWithTransitionContext:completion:] + 440 frame #46: 0x0000000194a52d44 FrontBoardServices__94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke.200 + 128
frame #47 (closed): 0x0000000194a366a4 FrontBoardServices-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 240 frame #48: 0x0000000194a52a0c FrontBoardServices__94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke + 372
frame #49 (closed): 0x0000000106a11de0 libdispatch.dylib_dispatch_client_callout + 20 frame #50: 0x0000000106a1586c libdispatch.dylib_dispatch_block_invoke_direct + 364
frame #51 (closed): 0x0000000194a7afa0 FrontBoardServices__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 48 frame #52: 0x0000000194a7ac30 FrontBoardServices-[FBSSerialQueue _targetQueue_performNextIfPossible] + 448
frame #53 (closed): 0x0000000194a7b184 FrontBoardServices-[FBSSerialQueue _performNextFromRunLoopSource] + 32 frame #54: 0x00000001853cf990 CoreFoundationCFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION + 28
frame #55 (closed): 0x00000001853cf88c CoreFoundation__CFRunLoopDoSource0 + 208 frame #56: 0x00000001853ceb90 CoreFoundation__CFRunLoopDoSources0 + 268
frame #57 (closed): 0x00000001853c8b70 CoreFoundation__CFRunLoopRun + 820 frame #58: 0x00000001853c8308 CoreFoundationCFRunLoopRunSpecific + 600
frame #59 (closed): 0x000000019ca4b734 GraphicsServicesGSEventRunModal + 164 frame #60: 0x0000000187e4675c UIKitCore-[UIApplication _run] + 1072
frame #61 (closed): 0x0000000187e4bfcc UIKitCoreUIApplicationMain + 168 frame #62: 0x00000001026d69f0 Runnermain at AppDelegate.swift:7:13
frame #63 (closed): 0x0000000185084cf8 libdyld.dylib`start + 4

```